### PR TITLE
handle either tidy or tidy5 as executable name

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -3,9 +3,25 @@
 use alienfile;
 
 plugin 'PkgConfig' => (
-    pkg_name        => [qw/ tidy tidy5 tidy-html5 /],
+    pkg_name        => 'tidy',
     minimum_version => '5.6.0',
 );
+
+meta->around_hook('probe' => sub {
+    my($orig, $build) = @_;
+
+    my $type = $orig->($build);
+    if($type eq 'system') {
+        foreach my $exe (qw( tidy5 tidy )) {
+            if(`$exe -version` =~ /HTML Tidy /) {
+                $build->runtime_prop->{command} = $exe;
+                return 'system';
+            }
+        }
+    }
+
+    return 'share';
+});
 
 share {
 
@@ -32,10 +48,9 @@ share {
         '%{make} install',
     ];
 
-};
+    after 'gather' => sub {
+        my($build) = @_;
+        $build->runtime_prop->{command} = 'tidy';
+    };
 
-gather [
-    [ 'pkg-config --modversion tidy', \'%{.runtime.version}' ],
-    [ 'pkg-config --cflags     tidy', \'%{.runtime.cflags}' ],
-    [ 'pkg-config --libs       tidy', \'%{.runtime.libs}' ],
-];
+};

--- a/cpanfile
+++ b/cpanfile
@@ -22,10 +22,9 @@ on 'test' => sub {
 };
 
 on 'configure' => sub {
-  requires "Alien::Build" => "1.19";
+  requires "Alien::Build" => "1.40";
   requires "Alien::Build::MM" => "0.32";
   requires "Alien::Build::Plugin::Build::CMake" => "0.99";
-  requires "Alien::Build::Plugin::PkgConfig::Negotiate" => "0.79";
   requires "ExtUtils::MakeMaker" => "6.52";
 };
 

--- a/lib/Alien/TidyHTML5.pm
+++ b/lib/Alien/TidyHTML5.pm
@@ -37,12 +37,7 @@ This returns the path of the F<tidy> executable.
 
 sub exe_file {
     my ($self) = @_;
-    if ( my $bin = $self->bin_dir ) {
-        return first { -x $_ } map { catfile( $bin, $_ ) } qw/ tidy tidy5 /;
-    }
-    else {
-        return undef;
-    }
+    $self->runtime_prop->{command};
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
I think this will resolve #2.

I think you were on the right track adding a method to provide the executable name at runtime, but the `bin_dir` function returns the paths that are necessary to _add_ to the `$PATH` in order to find the executable,  meaning for a system install it should be empty since it will already be in `$PATH`.  This is kind of annoying but it is what you want, if the exe is already in the `$PATH` you don't want to be adding it again in a different order!  So as written, the `exe_file` function won't ever work for a system install.

The usual way that I go about this is when there is an executable which might be called something different is to probe for the name at install time and store it in the runtime_prop's as `command` (this is actually the reserved property name for this, although I don't think any of the plugins actually use it).  `Alien::gmake`, which provides Gnu make as either `make` or `gmake` is a good example, although it is also doing a lot of other things so it might not be the most readable example.